### PR TITLE
prefer an exception filter

### DIFF
--- a/Src/AsyncAwaitBestPractices/TaskExtensions.cs
+++ b/Src/AsyncAwaitBestPractices/TaskExtensions.cs
@@ -19,11 +19,8 @@
             {
                 await task.ConfigureAwait(continueOnCapturedContext);
             }
-            catch (System.Exception ex)
+            catch (System.Exception ex) when (onException != null)
             {
-                if (onException is null)
-                    throw;
-
                 onException?.Invoke(ex);
             }
         }


### PR DESCRIPTION
Using an execption filter instead of a conditional inside the catch clause preserves the call stack for any code that eventually catches or logs the error.