### PR TITLE
prefer compile time to runtime checks

### DIFF
--- a/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
@@ -71,9 +71,9 @@ namespace AsyncAwaitBestPractices.MVVM
         void ICommand.Execute(object parameter)
         {
             if (parameter is T validParameter)
-                ExecuteAsync(validParameter)?.SafeFireAndForget(_continueOnCapturedContext, _onException);
+                ExecuteAsync(validParameter).SafeFireAndForget(_continueOnCapturedContext, _onException);
             else if (parameter is null && !typeof(T).IsValueType)
-                ExecuteAsync((T)parameter)?.SafeFireAndForget(_continueOnCapturedContext, _onException);
+                ExecuteAsync((T)parameter).SafeFireAndForget(_continueOnCapturedContext, _onException);
 
             throw new InvalidCommandParameterException(typeof(T), parameter.GetType());
         }

--- a/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
@@ -74,8 +74,8 @@ namespace AsyncAwaitBestPractices.MVVM
                 ExecuteAsync(validParameter).SafeFireAndForget(_continueOnCapturedContext, _onException);
             else if (parameter is null && !typeof(T).IsValueType)
                 ExecuteAsync((T)parameter).SafeFireAndForget(_continueOnCapturedContext, _onException);
-
-            throw new InvalidCommandParameterException(typeof(T), parameter.GetType());
+            else
+                throw new InvalidCommandParameterException(typeof(T), parameter.GetType());
         }
         #endregion
     }

--- a/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
@@ -31,9 +31,9 @@ namespace AsyncAwaitBestPractices.MVVM
                             bool continueOnCapturedContext = true)
         {
             _execute = execute ?? throw new ArgumentNullException(nameof(execute), $"{nameof(execute)} cannot be null");
-            _continueOnCapturedContext = continueOnCapturedContext;
-            _onException = onException;
             _canExecute = canExecute ?? (_ => true);
+            _onException = onException;
+            _continueOnCapturedContext = continueOnCapturedContext;
         }
         #endregion
 
@@ -107,9 +107,9 @@ namespace AsyncAwaitBestPractices.MVVM
                             bool continueOnCapturedContext = true)
         {
             _execute = execute ?? throw new ArgumentNullException(nameof(execute), $"{nameof(execute)} cannot be null");
-            _continueOnCapturedContext = continueOnCapturedContext;
-            _onException = onException;
             _canExecute = canExecute ?? (_ => true);
+            _onException = onException;
+            _continueOnCapturedContext = continueOnCapturedContext;
         }
         #endregion
 

--- a/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
@@ -145,7 +145,7 @@ namespace AsyncAwaitBestPractices.MVVM
 
         public Task ExecuteAsync() => _execute();
 
-        void ICommand.Execute(object parameter) => _execute()?.SafeFireAndForget(_continueOnCapturedContext, _onException);
+        void ICommand.Execute(object parameter) => _execute().SafeFireAndForget(_continueOnCapturedContext, _onException);
         #endregion
     }
 }

--- a/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
@@ -30,9 +30,7 @@ namespace AsyncAwaitBestPractices.MVVM
                             Action<Exception> onException = null,
                             bool continueOnCapturedContext = true)
         {
-            if (execute == null)
-                throw new ArgumentNullException(paramName: nameof(execute), "command handler can't be null");
-            _execute = execute;
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute), $"{nameof(execute)} cannot be null");
             _continueOnCapturedContext = continueOnCapturedContext;
             _onException = onException;
             _canExecute = canExecute ?? (_ => true);

--- a/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.MVVM/AsyncCommand.cs
@@ -106,9 +106,7 @@ namespace AsyncAwaitBestPractices.MVVM
                             Action<Exception> onException = null,
                             bool continueOnCapturedContext = true)
         {
-            if (execute == null)
-                throw new ArgumentNullException(paramName: nameof(execute), "command handler can't be null");
-            _execute = execute;
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute), $"{nameof(execute)} cannot be null");
             _continueOnCapturedContext = continueOnCapturedContext;
             _onException = onException;
             _canExecute = canExecute ?? (_ => true);

--- a/Src/AsyncAwaitBestPractices.MVVM/IAsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.MVVM/IAsyncCommand.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// An Async implmentation of ICommand
     /// </summary>
-    public interface IAsyncCommand : System.Windows.Input.ICommand
+    public interface IAsyncCommand<T> : System.Windows.Input.ICommand
     {
         /// <summary>
         /// Executes the Command as a Task
@@ -11,6 +11,18 @@
         /// <returns>The executed Task</returns>
         /// <param name="parameter">Data used by the command. If the command does not require data to be passed, this object can be set to null.</param>
 
-        System.Threading.Tasks.Task ExecuteAsync(object parameter);
+        System.Threading.Tasks.Task ExecuteAsync(T parameter);
+    }
+
+    /// <summary>
+    /// An Async implmentation of ICommand
+    /// </summary>
+    public interface IAsyncCommand : System.Windows.Input.ICommand
+    {
+        /// <summary>
+        /// Executes the Command as a Task
+        /// </summary>
+        /// <returns>The executed Task</returns>
+        System.Threading.Tasks.Task ExecuteAsync();
     }
 }

--- a/Src/AsyncAwaitBestPractices.MVVM/IAsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.MVVM/IAsyncCommand.cs
@@ -10,7 +10,6 @@
         /// </summary>
         /// <returns>The executed Task</returns>
         /// <param name="parameter">Data used by the command. If the command does not require data to be passed, this object can be set to null.</param>
-
         System.Threading.Tasks.Task ExecuteAsync(T parameter);
     }
 

--- a/Src/AsyncAwaitBestPractices.UnitTests/Tests_AsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.UnitTests/Tests_AsyncCommand.cs
@@ -37,54 +37,6 @@ namespace AsyncAwaitBestPractices.UnitTests
 
         }
 
-        [Test]
-        public async Task AsyncCommand_ExecuteAsync_InvalidValueTypeParameter_Test()
-        {
-            //Arrange
-            InvalidCommandParameterException actualInvalidCommandParameterException = null;
-            InvalidCommandParameterException expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(string), typeof(int));
-
-            AsyncCommand<string> command = new AsyncCommand<string>(StringParameterTask);
-
-            //Act
-            try
-            {
-                await command.ExecuteAsync(500);
-            }
-            catch(InvalidCommandParameterException e)
-            {
-                actualInvalidCommandParameterException = e;
-            }
-
-            //Assert
-            Assert.IsNotNull(actualInvalidCommandParameterException);
-            Assert.AreEqual(expectedInvalidCommandParameterException.Message, actualInvalidCommandParameterException.Message);
-        }
-
-        [Test]
-        public async Task AsyncCommand_ExecuteAsync_InvalidReferenceTypeParameter_Test()
-        {
-            //Arrange
-            InvalidCommandParameterException actualInvalidCommandParameterException = null;
-            InvalidCommandParameterException expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int), typeof(string));
-
-            AsyncCommand<int> command = new AsyncCommand<int>(IntParameterTask);
-
-            //Act
-            try
-            {
-                await command.ExecuteAsync("Hello World");
-            }
-            catch (InvalidCommandParameterException e)
-            {
-                actualInvalidCommandParameterException = e;
-            }
-
-            //Assert
-            Assert.IsNotNull(actualInvalidCommandParameterException);
-            Assert.AreEqual(expectedInvalidCommandParameterException.Message, actualInvalidCommandParameterException.Message);
-        }
-
         [TestCase(false)]
         [TestCase(true)]
         public async Task AsyncCommand_ExecuteAsync_NoParameter_ContinueOnCapturedContext_Test(bool continueOnCapturedContext)
@@ -94,7 +46,7 @@ namespace AsyncAwaitBestPractices.UnitTests
             var callingThreadId = Thread.CurrentThread.ManagedThreadId;
 
             //Act
-            await command.ExecuteAsync(null);
+            await command.ExecuteAsync();
 
             var returningThreadId = Thread.CurrentThread.ManagedThreadId;
 

--- a/Src/AsyncAwaitBestPractices.UnitTests/Tests_IAsyncCommand.cs
+++ b/Src/AsyncAwaitBestPractices.UnitTests/Tests_IAsyncCommand.cs
@@ -12,7 +12,7 @@ namespace AsyncAwaitBestPractices.UnitTests
         public async Task AsyncCommand_ExecuteAsync_IntParameter_Test(int parameter)
         {
             //Arrange
-            IAsyncCommand command = new AsyncCommand<int>(IntParameterTask);
+            IAsyncCommand<int> command = new AsyncCommand<int>(IntParameterTask);
 
             //Act
             await command.ExecuteAsync(parameter);
@@ -26,63 +26,13 @@ namespace AsyncAwaitBestPractices.UnitTests
         public async Task AsyncCommand_ExecuteAsync_StringParameter_Test(string parameter)
         {
             //Arrange
-            IAsyncCommand command = new AsyncCommand<string>(StringParameterTask);
+            IAsyncCommand<string> command = new AsyncCommand<string>(StringParameterTask);
 
             //Act
             await command.ExecuteAsync(parameter);
 
             //Assert
 
-        }
-
-        [Test]
-        public async Task AsyncCommand_ExecuteAsync_InvalidValueTypeParameter_Test()
-        {
-            //Arrange
-            InvalidCommandParameterException actualInvalidCommandParameterException = null;
-            InvalidCommandParameterException expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(string), typeof(int));
-
-
-            IAsyncCommand command = new AsyncCommand<string>(StringParameterTask);
-
-            //Act
-            try
-            {
-                await command.ExecuteAsync(500);
-            }
-            catch (InvalidCommandParameterException e)
-            {
-                actualInvalidCommandParameterException = e;
-            }
-
-            //Assert
-            Assert.IsNotNull(actualInvalidCommandParameterException);
-            Assert.AreEqual(expectedInvalidCommandParameterException.Message, actualInvalidCommandParameterException.Message);
-        }
-
-        [Test]
-        public async Task AsyncCommand_ExecuteAsync_InvalidReferenceTypeParameter_Test()
-        {
-            //Arrange
-            InvalidCommandParameterException actualInvalidCommandParameterException = null;
-            InvalidCommandParameterException expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int), typeof(string));
-
-
-            IAsyncCommand command = new AsyncCommand<int>(IntParameterTask);
-
-            //Act
-            try
-            {
-                await command.ExecuteAsync("Hello World");
-            }
-            catch (InvalidCommandParameterException e)
-            {
-                actualInvalidCommandParameterException = e;
-            }
-
-            //Assert
-            Assert.IsNotNull(actualInvalidCommandParameterException);
-            Assert.AreEqual(expectedInvalidCommandParameterException.Message, actualInvalidCommandParameterException.Message);
         }
 
         [TestCase(false)]
@@ -94,7 +44,7 @@ namespace AsyncAwaitBestPractices.UnitTests
             var callingThreadId = Thread.CurrentThread.ManagedThreadId;
 
             //Act
-            await command.ExecuteAsync(null);
+            await command.ExecuteAsync();
 
             var returningThreadId = Thread.CurrentThread.ManagedThreadId;
 
@@ -104,10 +54,10 @@ namespace AsyncAwaitBestPractices.UnitTests
 
         [TestCase(500, false)]
         [TestCase(500, true)]
-        public async Task IAsyncCommand_ExecuteAsync_Parameter_ContinueOnCapturedContext_Test(object parameter, bool continueOnCapturedContext)
+        public async Task IAsyncCommand_ExecuteAsync_Parameter_ContinueOnCapturedContext_Test(int parameter, bool continueOnCapturedContext)
         {
             //Arrange
-            IAsyncCommand command = new AsyncCommand<int>(IntParameterTask, continueOnCapturedContext: continueOnCapturedContext);
+            IAsyncCommand<int> command = new AsyncCommand<int>(IntParameterTask, continueOnCapturedContext: continueOnCapturedContext);
             var callingThreadId = Thread.CurrentThread.ManagedThreadId;
 
             //Act
@@ -123,7 +73,7 @@ namespace AsyncAwaitBestPractices.UnitTests
         public void IAsyncCommand_Parameter_CanExecuteTrue_Test()
         {
             //Arrange
-            IAsyncCommand command = new AsyncCommand<int>(IntParameterTask, CanExecuteTrue);
+            IAsyncCommand<int> command = new AsyncCommand<int>(IntParameterTask, CanExecuteTrue);
 
             //Act
 
@@ -135,7 +85,7 @@ namespace AsyncAwaitBestPractices.UnitTests
         public void IAsyncCommand_Parameter_CanExecuteFalse_Test()
         {
             //Arrange
-            IAsyncCommand command = new AsyncCommand<int>(IntParameterTask, canExecute: CanExecuteFalse);
+            IAsyncCommand<int> command = new AsyncCommand<int>(IntParameterTask, canExecute: CanExecuteFalse);
 
             //Act
 


### PR DESCRIPTION
There are several changes here. They all relate to leveraging compile time checks over runtime checks.  The changes are:

1. Use `.` instead of `?.` when the object invariant guarantees that a member can't be null.
1. Allow `null` for the onException handler to flow to the SafeFireAndForget, based on how the exception handling for that routine is written.
1. Split `IAsyncCommand` into two interfaces: IAsyncCommand, for commands that do not take an argument, and IAsyncCommand<T> for commands that take a single argument.
Making IAsyncCommand<T> a generic interface means that several tests are not needed, because an invalid argument type is not possible.