### PR TITLE
Improve ArgumentNullException message

### DIFF
--- a/Src/AsyncAwaitBestPractices/SafeFireAndForgetExtensions.cs
+++ b/Src/AsyncAwaitBestPractices/SafeFireAndForgetExtensions.cs
@@ -109,7 +109,7 @@ namespace AsyncAwaitBestPractices
         public static void SetDefaultExceptionHandling(in Action<Exception> onException)
         {
             if (onException is null)
-                throw new ArgumentNullException(nameof(onException), $"{onException} cannot be null");
+                throw new ArgumentNullException(nameof(onException));
 
             _onException = onException;
         }


### PR DESCRIPTION
With the current version, the message will always be " cannot be null", the default message will name the parameter.