### PR TITLE
Properly invoke DynamicMethods

### DIFF
--- a/Src/AsyncAwaitBestPractices.UnitTests/WeakEventManager Tests/Tests_WeakEventManager_Delegate.cs
+++ b/Src/AsyncAwaitBestPractices.UnitTests/WeakEventManager Tests/Tests_WeakEventManager_Delegate.cs
@@ -124,6 +124,23 @@ namespace AsyncAwaitBestPractices.UnitTests
         }
 
         [Test]
+        public void WeakEventManagerDelegate_HandleEvent_DynamicMethod()
+        {
+            //Arrange
+            var dynamicMethod = new System.Reflection.Emit.DynamicMethod(string.Empty, typeof(void), new[] { typeof(object), typeof(PropertyChangedEventArgs) });
+            var ilGenerator = dynamicMethod.GetILGenerator();
+            ilGenerator.Emit(System.Reflection.Emit.OpCodes.Ret);
+            var handler = dynamicMethod.CreateDelegate(typeof(PropertyChangedEventHandler)) as PropertyChangedEventHandler;
+            PropertyChanged += handler;
+
+            //Act
+
+            //Assert
+            Assert.DoesNotThrow(() => _propertyChangedWeakEventManager.RaiseEvent(this, new PropertyChangedEventArgs("Test"), nameof(PropertyChanged)));
+            PropertyChanged -= handler;
+        }
+
+        [Test]
         public void WeakEventManagerDelegate_UnassignedEvent()
         {
             //Arrange

--- a/Src/AsyncAwaitBestPractices.UnitTests/WeakEventManager Tests/Tests_WeakEventManager_Delegate.cs
+++ b/Src/AsyncAwaitBestPractices.UnitTests/WeakEventManager Tests/Tests_WeakEventManager_Delegate.cs
@@ -124,7 +124,7 @@ namespace AsyncAwaitBestPractices.UnitTests
         }
 
         [Test]
-        public void WeakEventManagerDelegate_HandleEvent_DynamicMethod()
+        public void WeakEventManagerDelegate_HandleEvent_DynamicMethod_ValidImplementation()
         {
             //Arrange
             var dynamicMethod = new System.Reflection.Emit.DynamicMethod(string.Empty, typeof(void), new[] { typeof(object), typeof(PropertyChangedEventArgs) });

--- a/Src/AsyncAwaitBestPractices/AsyncAwaitBestPractices.csproj
+++ b/Src/AsyncAwaitBestPractices/AsyncAwaitBestPractices.csproj
@@ -15,6 +15,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+      <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     </ItemGroup>
     <ItemGroup>
       <Folder Include="WeakEventManager\" />

--- a/Src/AsyncAwaitBestPractices/WeakEventManager/EventManagerService.cs
+++ b/Src/AsyncAwaitBestPractices/WeakEventManager/EventManagerService.cs
@@ -1,11 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 
 namespace AsyncAwaitBestPractices
 {
     static class EventManagerService
     {
+        public static bool IsLightweightMethod(this MethodBase method)
+        {
+            TypeInfo typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
+            return method is DynamicMethod || typeInfoRTDynamicMethod.IsAssignableFrom(method.GetType().GetTypeInfo());
+        }
+
+        public static DynamicMethod? TryGetDynamicMethod(MethodInfo rtDynamicMethod)
+        {
+            TypeInfo typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
+            Type? typeRTDynamicMethod = typeInfoRTDynamicMethod.AsType();
+
+            return typeInfoRTDynamicMethod.IsAssignableFrom(rtDynamicMethod.GetType().GetTypeInfo())
+                ? (DynamicMethod)typeRTDynamicMethod.GetRuntimeFields().First(f => f.Name == "m_owner").GetValue(rtDynamicMethod)
+                : null;
+        }
+
         internal static void AddEventHandler(in string eventName, in object? handlerTarget, in MethodInfo? methodInfo, in Dictionary<string, List<Subscription>> eventHandlers)
         {
             var doesContainSubscriptions = eventHandlers.TryGetValue(eventName, out List<Subscription>? targets);
@@ -51,7 +69,15 @@ namespace AsyncAwaitBestPractices
                 try
                 {
                     Tuple<object?, MethodInfo> tuple = toRaise[i];
-                    tuple.Item2.Invoke(tuple.Item1, new[] { sender, eventArgs });
+                    if (tuple.Item2.IsLightweightMethod())
+                    {
+                        var method = TryGetDynamicMethod(tuple.Item2);
+                        method?.Invoke(tuple.Item1, new[] { sender, eventArgs });
+                    }
+                    else
+                    {
+                        tuple.Item2.Invoke(tuple.Item1, new[] { sender, eventArgs });
+                    }
                 }
                 catch (TargetParameterCountException e)
                 {
@@ -69,8 +95,16 @@ namespace AsyncAwaitBestPractices
             {
                 try
                 {
-                    var tuple = toRaise[i];
-                    tuple.Item2.Invoke(tuple.Item1, new[] { actionEventArgs });
+                    Tuple<object?, MethodInfo> tuple = toRaise[i];
+                    if (tuple.Item2.IsLightweightMethod())
+                    {
+                        var method = TryGetDynamicMethod(tuple.Item2);
+                        method?.Invoke(tuple.Item1, new[] { actionEventArgs });
+                    }
+                    else
+                    {
+                        tuple.Item2.Invoke(tuple.Item1, new[] { actionEventArgs });
+                    }
                 }
                 catch (TargetParameterCountException e)
                 {
@@ -87,8 +121,16 @@ namespace AsyncAwaitBestPractices
             {
                 try
                 {
-                    var tuple = toRaise[i];
-                    tuple.Item2.Invoke(tuple.Item1, null);
+                    Tuple<object?, MethodInfo> tuple = toRaise[i];
+                    if (tuple.Item2.IsLightweightMethod())
+                    {
+                        var method = TryGetDynamicMethod(tuple.Item2);
+                        method?.Invoke(tuple.Item1, null);
+                    }
+                    else
+                    {
+                        tuple.Item2.Invoke(tuple.Item1, null);
+                    }
                 }
                 catch (TargetParameterCountException e)
                 {

--- a/Src/AsyncAwaitBestPractices/WeakEventManager/EventManagerService.cs
+++ b/Src/AsyncAwaitBestPractices/WeakEventManager/EventManagerService.cs
@@ -8,13 +8,13 @@ namespace AsyncAwaitBestPractices
 {
     static class EventManagerService
     {
-        public static bool IsLightweightMethod(this MethodBase method)
+        internal static bool IsLightweightMethod(this MethodBase method)
         {
             TypeInfo typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
             return method is DynamicMethod || typeInfoRTDynamicMethod.IsAssignableFrom(method.GetType().GetTypeInfo());
         }
 
-        public static DynamicMethod? TryGetDynamicMethod(MethodInfo rtDynamicMethod)
+        internal static DynamicMethod? TryGetDynamicMethod(MethodInfo rtDynamicMethod)
         {
             TypeInfo typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
             Type? typeRTDynamicMethod = typeInfoRTDynamicMethod.AsType();


### PR DESCRIPTION
Regarding https://github.com/brminnick/AsyncAwaitBestPractices/issues/36.

.NET Standard 1.0 has some pretty annoying limitations on the API for reflection and dynamic methods. I have figured out a way to do what needs to be done but I'm not sure if it is the best approach. I'm certainly not an expert in dynamic methods.

This PR detects when a handler is dynamic and invokes it properly.