### PR TITLE
Add Global.Json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "3.1.100",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100",
+    "version": "5.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Xamarin dependencies for preview versions of
.NET Core are still not reliable for building
projects. Keeping the projects targeting the
latest stable release of .NET Core makes for
more reliable cross-platform build experiences.