### PR TITLE
Prevent ArgumentOutOfRangeException

### DIFF
--- a/Src/AsyncAwaitBestPractices.MVVM/AsyncAwaitBestPractices.MVVM.csproj
+++ b/Src/AsyncAwaitBestPractices.MVVM/AsyncAwaitBestPractices.MVVM.csproj
@@ -29,12 +29,12 @@
 - Update AssemblyFileVersion
 - Add NuGet README
         </PackageReleaseNotes>
-        <Version>6.0.2</Version>
+        <Version>6.0.3</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/brminnick/AsyncAwaitBestPractices</RepositoryUrl>
         <Product>$(AssemblyName) ($(TargetFramework))</Product>
-        <AssemblyVersion>6.0.1</AssemblyVersion>
-        <AssemblyFileVersion>6.0.1</AssemblyFileVersion>
+        <AssemblyVersion>6.0.3</AssemblyVersion>
+        <AssemblyFileVersion>6.0.3</AssemblyFileVersion>
         <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
         <Authors>Brandon Minnick, John Thiriet</Authors>
         <Owners>Brandon Minnick</Owners>

--- a/Src/AsyncAwaitBestPractices.UnitTests/AsyncAwaitBestPractices.UnitTests.csproj
+++ b/Src/AsyncAwaitBestPractices.UnitTests/AsyncAwaitBestPractices.UnitTests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net45</TargetFrameworks>
+        <TargetFrameworks>net45;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/Src/AsyncAwaitBestPractices.UnitTests/WeakEventManagerTests/Tests_WeakEventManager_Delegate.cs
+++ b/Src/AsyncAwaitBestPractices.UnitTests/WeakEventManagerTests/Tests_WeakEventManager_Delegate.cs
@@ -285,7 +285,7 @@ namespace AsyncAwaitBestPractices.UnitTests
         }
 
         [Test]
-        public void WeakEventManagerDelegate_RemoveEventHandler_ArgumentOutOfRangeException()
+        public void WeakEventManagerDelegate_RemoveEventHandler_NoArgumentOutOfRangeException()
         {
             //Arrange
 
@@ -294,19 +294,9 @@ namespace AsyncAwaitBestPractices.UnitTests
             _propertyChangedWeakEventManager.AddEventHandler(sampleDelegate, nameof(sampleDelegate));
 
             //Assert
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            Assert.DoesNotThrow(() =>
             {
-                try
-                {
-                    Parallel.For(0, 2, count => _propertyChangedWeakEventManager.RemoveEventHandler(sampleDelegate, nameof(sampleDelegate)));
-                }
-                catch (AggregateException e)
-                {
-                    if (e.InnerExceptions.Count is 1)
-                        throw e.InnerExceptions[0];
-
-                    throw;
-                }
+                Parallel.For(0, 10, count => _propertyChangedWeakEventManager.RemoveEventHandler(sampleDelegate, nameof(sampleDelegate)));
             });
 
             static void sampleDelegate(object? sender, EventArgs e)

--- a/Src/AsyncAwaitBestPractices.UnitTests/WeakEventManagerTests/Tests_WeakEventManager_Delegate.cs
+++ b/Src/AsyncAwaitBestPractices.UnitTests/WeakEventManagerTests/Tests_WeakEventManager_Delegate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace AsyncAwaitBestPractices.UnitTests
@@ -282,5 +283,37 @@ namespace AsyncAwaitBestPractices.UnitTests
             //Assert
             Assert.Throws<ArgumentNullException>(() => _propertyChangedWeakEventManager.RemoveEventHandler(null, " "), "Value cannot be null.\nParameter name: eventName");
         }
+
+        [Test]
+        public void WeakEventManagerDelegate_RemoveEventHandler_ArgumentOutOfRangeException()
+        {
+            //Arrange
+
+
+            //Act
+            _propertyChangedWeakEventManager.AddEventHandler(sampleDelegate, nameof(sampleDelegate));
+
+            //Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                try
+                {
+                    Parallel.For(0, 2, count => _propertyChangedWeakEventManager.RemoveEventHandler(sampleDelegate, nameof(sampleDelegate)));
+                }
+                catch (AggregateException e)
+                {
+                    if (e.InnerExceptions.Count is 1)
+                        throw e.InnerExceptions[0];
+
+                    throw;
+                }
+            });
+
+            static void sampleDelegate(object? sender, EventArgs e)
+            {
+
+            }
+        }
+
     }
 }

--- a/Src/AsyncAwaitBestPractices/AsyncAwaitBestPractices.csproj
+++ b/Src/AsyncAwaitBestPractices/AsyncAwaitBestPractices.csproj
@@ -31,12 +31,12 @@
 - Update AssemblyFileVersion
 - Add NuGet README
         </PackageReleaseNotes>
-        <Version>6.0.2</Version>
+        <Version>6.0.3</Version>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/brminnick/AsyncAwaitBestPractices</RepositoryUrl>
         <Product>$(AssemblyName) ($(TargetFramework))</Product>
-        <AssemblyVersion>6.0.1</AssemblyVersion>
-        <AssemblyFileVersion>6.0.1</AssemblyFileVersion>
+        <AssemblyVersion>6.0.3</AssemblyVersion>
+        <AssemblyFileVersion>6.0.3</AssemblyFileVersion>
         <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
         <Authors>Brandon Minnick, John Thiriet</Authors>
         <Owners>Brandon Minnick</Owners>

--- a/Src/AsyncAwaitBestPractices/WeakEventManager/EventManagerService.shared.cs
+++ b/Src/AsyncAwaitBestPractices/WeakEventManager/EventManagerService.shared.cs
@@ -6,171 +6,179 @@ using System.Reflection.Emit;
 
 namespace AsyncAwaitBestPractices
 {
-	static class EventManagerService
-	{
-		internal static void AddEventHandler(in string eventName, in object? handlerTarget, in MethodInfo methodInfo, in Dictionary<string, List<Subscription>> eventHandlers)
-		{
-			var doesContainSubscriptions = eventHandlers.TryGetValue(eventName, out var targets);
-			if (!doesContainSubscriptions || targets is null)
-			{
-				targets = new List<Subscription>();
-				eventHandlers.Add(eventName, targets);
-			}
+    static class EventManagerService
+    {
+        static readonly object _lock = new();
 
-			if (handlerTarget is null)
-				targets.Add(new Subscription(null, methodInfo));
-			else
-				targets.Add(new Subscription(new WeakReference(handlerTarget), methodInfo));
-		}
+        internal static void AddEventHandler(in string eventName, in object? handlerTarget, in MethodInfo methodInfo, in Dictionary<string, List<Subscription>> eventHandlers)
+        {
+            lock (_lock)
+            {
+                var doesContainSubscriptions = eventHandlers.TryGetValue(eventName, out var targets);
+                if (!doesContainSubscriptions || targets is null)
+                {
+                    targets = new List<Subscription>();
+                    eventHandlers.Add(eventName, targets);
+                }
 
-		internal static void RemoveEventHandler(in string eventName, in object? handlerTarget, in MemberInfo methodInfo, in Dictionary<string, List<Subscription>> eventHandlers)
-		{
-			var doesContainSubscriptions = eventHandlers.TryGetValue(eventName, out var subscriptions);
-			if (!doesContainSubscriptions || subscriptions is null)
-				return;
+                if (handlerTarget is null)
+                    targets.Add(new Subscription(null, methodInfo));
+                else
+                    targets.Add(new Subscription(new WeakReference(handlerTarget), methodInfo));
+            }
+        }
 
-			for (var n = subscriptions.Count; n > 0; n--)
-			{
-				var current = subscriptions[n - 1];
+        internal static void RemoveEventHandler(in string eventName, in object? handlerTarget, in MemberInfo methodInfo, in Dictionary<string, List<Subscription>> eventHandlers)
+        {
+            lock (_lock)
+            {
+                var doesContainSubscriptions = eventHandlers.TryGetValue(eventName, out var subscriptions);
+                if (!doesContainSubscriptions || subscriptions is null)
+                    return;
 
-				if (current.Subscriber?.Target != handlerTarget
-					|| current.Handler.Name != methodInfo?.Name)
-				{
-					continue;
-				}
+                for (var n = subscriptions.Count; n > 0; n--)
+                {
+                    var current = subscriptions[n - 1];
 
-				subscriptions.Remove(current);
-				break;
-			}
-		}
+                    if (current.Subscriber?.Target != handlerTarget
+                        || current.Handler.Name != methodInfo?.Name)
+                    {
+                        continue;
+                    }
 
-		internal static void HandleEvent(in string eventName, in object? sender, in object? eventArgs, in Dictionary<string, List<Subscription>> eventHandlers)
-		{
-			AddRemoveEvents(eventName, eventHandlers, out var toRaise);
+                    subscriptions.Remove(current);
+                    break;
+                }
+            }
+        }
 
-			for (var i = 0; i < toRaise.Count; i++)
-			{
-				try
-				{
-					var (instance, eventHandler) = toRaise[i];
-					if (eventHandler.IsLightweightMethod())
-					{
-						var method = TryGetDynamicMethod(eventHandler);
-						method?.Invoke(instance, new[] { sender, eventArgs });
-					}
-					else
-					{
-						eventHandler.Invoke(instance, new[] { sender, eventArgs });
-					}
-				}
-				catch (TargetParameterCountException e)
-				{
-					throw new InvalidHandleEventException("Parameter count mismatch. If invoking an `event Action` use `HandleEvent(string eventName)` or if invoking an `event Action<T>` use `HandleEvent(object eventArgs, string eventName)`instead.", e);
-				}
-			}
-		}
+        internal static void HandleEvent(in string eventName, in object? sender, in object? eventArgs, in Dictionary<string, List<Subscription>> eventHandlers)
+        {
+            AddRemoveEvents(eventName, eventHandlers, out var toRaise);
 
-		internal static void HandleEvent(in string eventName, in object? actionEventArgs, in Dictionary<string, List<Subscription>> eventHandlers)
-		{
-			AddRemoveEvents(eventName, eventHandlers, out var toRaise);
+            for (var i = 0; i < toRaise.Count; i++)
+            {
+                try
+                {
+                    var (instance, eventHandler) = toRaise[i];
+                    if (eventHandler.IsLightweightMethod())
+                    {
+                        var method = TryGetDynamicMethod(eventHandler);
+                        method?.Invoke(instance, new[] { sender, eventArgs });
+                    }
+                    else
+                    {
+                        eventHandler.Invoke(instance, new[] { sender, eventArgs });
+                    }
+                }
+                catch (TargetParameterCountException e)
+                {
+                    throw new InvalidHandleEventException("Parameter count mismatch. If invoking an `event Action` use `HandleEvent(string eventName)` or if invoking an `event Action<T>` use `HandleEvent(object eventArgs, string eventName)`instead.", e);
+                }
+            }
+        }
 
-			for (var i = 0; i < toRaise.Count; i++)
-			{
-				try
-				{
-					var (instance, eventHandler) = toRaise[i];
-					if (eventHandler.IsLightweightMethod())
-					{
-						var method = TryGetDynamicMethod(eventHandler);
-						method?.Invoke(instance, new[] { actionEventArgs });
-					}
-					else
-					{
-						eventHandler.Invoke(instance, new[] { actionEventArgs });
-					}
-				}
-				catch (TargetParameterCountException e)
-				{
-					throw new InvalidHandleEventException("Parameter count mismatch. If invoking an `event EventHandler` use `HandleEvent(object sender, TEventArgs eventArgs, string eventName)` or if invoking an `event Action` use `HandleEvent(string eventName)`instead.", e);
-				}
-			}
-		}
+        internal static void HandleEvent(in string eventName, in object? actionEventArgs, in Dictionary<string, List<Subscription>> eventHandlers)
+        {
+            AddRemoveEvents(eventName, eventHandlers, out var toRaise);
 
-		internal static void HandleEvent(in string eventName, in Dictionary<string, List<Subscription>> eventHandlers)
-		{
-			AddRemoveEvents(eventName, eventHandlers, out var toRaise);
+            for (var i = 0; i < toRaise.Count; i++)
+            {
+                try
+                {
+                    var (instance, eventHandler) = toRaise[i];
+                    if (eventHandler.IsLightweightMethod())
+                    {
+                        var method = TryGetDynamicMethod(eventHandler);
+                        method?.Invoke(instance, new[] { actionEventArgs });
+                    }
+                    else
+                    {
+                        eventHandler.Invoke(instance, new[] { actionEventArgs });
+                    }
+                }
+                catch (TargetParameterCountException e)
+                {
+                    throw new InvalidHandleEventException("Parameter count mismatch. If invoking an `event EventHandler` use `HandleEvent(object sender, TEventArgs eventArgs, string eventName)` or if invoking an `event Action` use `HandleEvent(string eventName)`instead.", e);
+                }
+            }
+        }
 
-			for (var i = 0; i < toRaise.Count; i++)
-			{
-				try
-				{
-					var (instance, eventHandler) = toRaise[i];
-					if (eventHandler.IsLightweightMethod())
-					{
-						var method = TryGetDynamicMethod(eventHandler);
-						method?.Invoke(instance, null);
-					}
-					else
-					{
-						eventHandler.Invoke(instance, null);
-					}
-				}
-				catch (TargetParameterCountException e)
-				{
-					throw new InvalidHandleEventException("Parameter count mismatch. If invoking an `event EventHandler` use `HandleEvent(object sender, TEventArgs eventArgs, string eventName)` or if invoking an `event Action<T>` use `HandleEvent(object eventArgs, string eventName)`instead.", e);
-				}
-			}
-		}
+        internal static void HandleEvent(in string eventName, in Dictionary<string, List<Subscription>> eventHandlers)
+        {
+            AddRemoveEvents(eventName, eventHandlers, out var toRaise);
 
-		static void AddRemoveEvents(in string eventName, in Dictionary<string, List<Subscription>> eventHandlers, out List<(object? Instance, MethodInfo EventHandler)> toRaise)
-		{
-			var toRemove = new List<Subscription>();
-			toRaise = new List<(object?, MethodInfo)>();
+            for (var i = 0; i < toRaise.Count; i++)
+            {
+                try
+                {
+                    var (instance, eventHandler) = toRaise[i];
+                    if (eventHandler.IsLightweightMethod())
+                    {
+                        var method = TryGetDynamicMethod(eventHandler);
+                        method?.Invoke(instance, null);
+                    }
+                    else
+                    {
+                        eventHandler.Invoke(instance, null);
+                    }
+                }
+                catch (TargetParameterCountException e)
+                {
+                    throw new InvalidHandleEventException("Parameter count mismatch. If invoking an `event EventHandler` use `HandleEvent(object sender, TEventArgs eventArgs, string eventName)` or if invoking an `event Action<T>` use `HandleEvent(object eventArgs, string eventName)`instead.", e);
+                }
+            }
+        }
 
-			var doesContainEventName = eventHandlers.TryGetValue(eventName, out var target);
-			if (doesContainEventName && target != null)
-			{
-				for (var i = 0; i < target.Count; i++)
-				{
-					var subscription = target[i];
-					var isStatic = subscription.Subscriber is null;
+        static void AddRemoveEvents(in string eventName, in Dictionary<string, List<Subscription>> eventHandlers, out List<(object? Instance, MethodInfo EventHandler)> toRaise)
+        {
+            var toRemove = new List<Subscription>();
+            toRaise = new List<(object?, MethodInfo)>();
 
-					if (isStatic)
-					{
-						toRaise.Add((null, subscription.Handler));
-						continue;
-					}
+            var doesContainEventName = eventHandlers.TryGetValue(eventName, out var target);
+            if (doesContainEventName && target != null)
+            {
+                for (var i = 0; i < target.Count; i++)
+                {
+                    var subscription = target[i];
+                    var isStatic = subscription.Subscriber is null;
 
-					var subscriber = subscription.Subscriber?.Target;
+                    if (isStatic)
+                    {
+                        toRaise.Add((null, subscription.Handler));
+                        continue;
+                    }
 
-					if (subscriber is null)
-						toRemove.Add(subscription);
-					else
-						toRaise.Add((subscriber, subscription.Handler));
-				}
+                    var subscriber = subscription.Subscriber?.Target;
 
-				for (var i = 0; i < toRemove.Count; i++)
-				{
-					var subscription = toRemove[i];
-					target.Remove(subscription);
-				}
-			}
-		}
+                    if (subscriber is null)
+                        toRemove.Add(subscription);
+                    else
+                        toRaise.Add((subscriber, subscription.Handler));
+                }
 
-		static DynamicMethod? TryGetDynamicMethod(in MethodInfo rtDynamicMethod)
-		{
-			var typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
-			var typeRTDynamicMethod = typeInfoRTDynamicMethod?.AsType();
+                for (var i = 0; i < toRemove.Count; i++)
+                {
+                    var subscription = toRemove[i];
+                    target.Remove(subscription);
+                }
+            }
+        }
 
-			return (typeInfoRTDynamicMethod?.IsAssignableFrom(rtDynamicMethod.GetType().GetTypeInfo()) ?? false) ?
-				 (DynamicMethod)typeRTDynamicMethod.GetRuntimeFields().First(f => f.Name is "m_owner").GetValue(rtDynamicMethod)
-				: null;
-		}
+        static DynamicMethod? TryGetDynamicMethod(in MethodInfo rtDynamicMethod)
+        {
+            var typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
+            var typeRTDynamicMethod = typeInfoRTDynamicMethod?.AsType();
 
-		static bool IsLightweightMethod(this MethodBase method)
-		{
-			var typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
-			return method is DynamicMethod || (typeInfoRTDynamicMethod?.IsAssignableFrom(method.GetType().GetTypeInfo()) ?? false);
-		}
-	}
+            return (typeInfoRTDynamicMethod?.IsAssignableFrom(rtDynamicMethod.GetType().GetTypeInfo()) ?? false) ?
+                 (DynamicMethod)typeRTDynamicMethod.GetRuntimeFields().First(f => f.Name is "m_owner").GetValue(rtDynamicMethod)
+                : null;
+        }
+
+        static bool IsLightweightMethod(this MethodBase method)
+        {
+            var typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
+            return method is DynamicMethod || (typeInfoRTDynamicMethod?.IsAssignableFrom(method.GetType().GetTypeInfo()) ?? false);
+        }
+    }
 }

--- a/Src/global.json
+++ b/Src/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
     "version": "6.0.*",
-    "rollForward": "patch",
-    "allowPrerelease": true
+    "rollForward": "patch"
   }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,32 @@ pool:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .Net Core sdk  3.x'
+  displayName: 'Use .Net Core SDK 2.1.x'
   inputs:
-    version: ' 3.x'
+    version: ' 2.1.x'
     includePreviewVersions: true
+    installationPath: '$(Agent.ToolsDirectory)'
+    performMultiLevelLookup: true
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core SDK 3.1.x'
+  inputs:
+    version: ' 3.1.x'
+    includePreviewVersions: true
+    installationPath: '$(Agent.ToolsDirectory)'
+    performMultiLevelLookup: true
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core SDK  5.0.x'
+  inputs:
+    version: ' 5.0.x'
+    installationPath: '$(Agent.ToolsDirectory)'
+    performMultiLevelLookup: true
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core SDK  6.0.x'
+  inputs:
+    version: ' 6.0.x'
     installationPath: '$(Agent.ToolsDirectory)'
     performMultiLevelLookup: true
 


### PR DESCRIPTION
### Description

This PR fixes a race condition that can happen when the same `event` is removed in parallel.

### Error 

```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. Parameter name: index

Stack Trace

AsyncAwaitBestPractices.EventManagerService.RemoveEventHandler (System.String& eventName, System.Object& handlerTarget, System.Reflection.MemberInfo& methodInfo, System.Collections.Generic.Dictionary`2[System.String,System.Collections.Generic.List`1[AsyncAwaitBestPractices.Subscription]]& eventHandlers) [0x0005c] in <63bee8e7afc14051bfc24f7fd7c5ed2c>:0;
AsyncAwaitBestPracticesAsyncAwaitBestPractices.WeakEventManager.RemoveEventHandler (System.Delegate& handler, System.String& eventName) [0x00035] in <63bee8e7afc14051bfc24f7fd7c5ed2c>:0;AsyncAwaitBestPracticesAsyncAwaitBestPractices.WeakEventManager.RemoveEventHandler (System.Delegate handler, System.String eventName) [0x00000] in <63bee8e7afc14051bfc24f7fd7c5ed2c>:0;AsyncAwaitBestPracticesGitTrends.GitHubAuthenticationService.remove_AuthorizeSessionStarted (System.EventHandler value) [0x00000] in <5bbcdde3e8a94c7aaeae05ae46b1d556>:0;
```

### Reproduction

```cs
Parallel.For(0, 10, count => _propertyChangedWeakEventManager.RemoveEventHandler(sampleDelegate, nameof(sampleDelegate)));

static void sampleDelegate(object? sender, EventArgs e)
{
}
```

### Detailed Description
- Adds `lock` to `EventManagerService.RemoveEventHandler` and `EventManagerService.AddEventHandler`
- Adds Unit Test to ensure race condition no longer occurs
- Adds .NET 6 support to Unit Tests
- Adds .NET 5 and .NET 6 Support to Azure Pipelines Build
- Increment to v6.0.3