### PR TITLE
Add Android SDK Step to `azure-pipelines.yml`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,10 +69,12 @@ jobs:
           packageType: 'sdk'
           includePreviewVersions: false
 
-      - powershell: |
-          dotnet workload install maui
-          dotnet worklaod update
-        displayName: Install Latest .NET MAUI Workload
+      - task: CmdLine@2
+        displayName: 'Install .NET MAUI Workload'
+        inputs:
+          script : |
+            dotnet workload install maui
+            dotnet workload update
 
       - task: NuGetToolInstaller@1
         displayName: 'Use NuGet'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,9 @@ jobs:
           packageType: 'sdk'
           includePreviewVersions: false
 
-      - powershell: dotnet workload install maui --skip-sign-check --source https://api.nuget.org/v3/index.json
+      - powershell: |
+          dotnet workload install maui
+          dotnet worklaod update
         displayName: Install Latest .NET MAUI Workload
 
       - task: NuGetToolInstaller@1


### PR DESCRIPTION
This PR updates the CI/CD pipeline, removing the build errors caused by the missing Android SDK